### PR TITLE
'license name missing' for install

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,20 +23,20 @@ fs.readdirSync(__dirname + '/licenses').map(function (license) {
  */
 program
   .command('install [license]')
-  .alias('i')
+  // .alias('i')
   .description('Use this command to generate a license file.')
   .option("-y, --year <year>", 'The year to use. Example: 2014.')
   .option("-n, --fullname <fullname>", 'Your fullname.')
   .option("-p, --project <project name>", "Project name.")
   .option("-e, --extension <extension>", 'The file extension for the license. Example: txt. Defaults to no extension.')
   .action(function (license, options) {
-    // Lowercase the provided license name
-    license = license.toLowerCase();
-
+    // Throw error if license is not provided
     if (!license) {
       console.log('Error: license name missing');
       program.help();
     }
+    // Lowercase the provided license name
+    license = license.toLowerCase();
 
     // Use provided year or default to current year.
     var year = options.year || new Date().getUTCFullYear();
@@ -83,13 +83,15 @@ program
   .command('view [license]')
   .description('Use this command to view the content of a license.')
   .action(function (license) {
-    // Lowercase the provided license name
-    license = license.toLowerCase();
 
+    // Throw error if not license is not provided
     if (!license) {
       console.log('Error: license name missing');
       program.help();
     }
+    // Lowercase the provided license name
+    license = license.toLowerCase();
+
 
     // Get license file.
     var license_file = __dirname + '/licenses/' + license + '.txt';

--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ program
     // Lowercase the provided license name
     license = license.toLowerCase();
 
+    if (!license) {
+      console.log('Error: license name missing');
+      program.help();
+    }
+
     // Use provided year or default to current year.
     var year = options.year || new Date().getUTCFullYear();
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ fs.readdirSync(__dirname + '/licenses').map(function (license) {
  */
 program
   .command('install [license]')
-  // .alias('i')
+  .alias('i')
   .description('Use this command to generate a license file.')
   .option("-y, --year <year>", 'The year to use. Example: 2014.')
   .option("-n, --fullname <fullname>", 'Your fullname.')


### PR DESCRIPTION
When using `license-generator install` without license name, it throws
```bash
{ [Error: ENOENT: no such file or directory, open '/usr/local/lib/node_modules/license-generator/licenses/undefined.txt']
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/usr/local/lib/node_modules/license-generator/licenses/undefined.txt' }
```

It would be better if it handle the same way as using `license-generator view`:
```bash
Error: license name missing
```