### PR TITLE
Unknown command

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,4 +124,6 @@ program.parse(process.argv);
 
 if (!program.args.length) {
   program.help();
+}else{
+  console.log('Unknown command. Use `license-generator --help` to learn more about commands available.');
 }


### PR DESCRIPTION
Print the following when neither `install` nor `view` were used.

```bash
Unknown command. Use `license-generator --help` to learn more about commands available.
```
 
For example:
```bash
$ license-generator test
Unknown command. Use `license-generator --help` to learn more about commands available.
```