### PR TITLE
able to use require

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,129 @@
+#! /usr/bin/env node
+
+var program = require('commander');
+var fs = require('fs');
+var path = require('path');
+var licenseGenerator = require('../index.js');
+
+// Get version from package.json.
+var version = require('../package.json').version;
+
+// Get available licenses.
+var licenses = [];
+fs.readdirSync(path.join(__dirname, '../licenses')).map(function (license) {
+  licenses.push(license.replace(/\.[0-9a-z]+$/i, ''));
+});
+
+// program
+//   .version(version)
+//   .option("-y, --year <year>", 'The year to use. Example: 2014.')
+//   .option("-n, --fullname <fullname>", 'Your fullname.')
+
+/**
+ * Install command.
+ * license-generator install [license]
+ */
+program
+  .command('install [license]')
+  // .alias('i')
+  .description('Use this command to generate a license file.')
+  .option("-y, --year <year>", 'The year to use. Example: 2014.')
+  .option("-n, --fullname <fullname>", 'Your fullname.')
+  .option("-p, --project <project name>", "Project name.")
+  .option("-e, --extension <extension>", 'The file extension for the license. Example: txt. Defaults to no extension.')
+  .action(function (license, options) {
+    // Lowercase the provided license name
+    license = license.toLowerCase();
+
+    // Use provided year or default to current year.
+    var year = options.year || new Date().getUTCFullYear();
+
+    //read from package.json and infer variable if not given
+    var packageJSON = {};
+    try{
+        packageJSON = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+    }catch(err){
+    }
+
+    // Use provided name or default to blank.
+    var fullname = options.fullname || packageJSON.author || '';
+
+    // Use the provided project or default to none
+    var projectname = options.project || packageJSON.name || '';
+
+    // Get file extension.
+    var extension = options.extension || '';
+
+    // Get file output location
+    var generated_license =  './LICENSE' + ((extension) ? '.' + extension : '');
+
+    licenseGenerator.install({
+        output: generated_license,
+        license: license,
+        year: year,
+        fullname: fullname,
+        projectname: projectname
+    }, function(err){
+        if (err) {
+          return console.log(err);
+        }
+        // Show a success message.
+        console.log('Successfully added ' + license + ' license to ' + generated_license + ' file.');
+    })
+  });
+
+/**
+ * View command.
+ * license-generator view [license]
+ */
+program
+  .command('view [license]')
+  .description('Use this command to view the content of a license.')
+  .action(function (license) {
+    // Lowercase the provided license name
+    license = license.toLowerCase();
+
+    if (!license) {
+      console.log('Error: license name missing');
+      program.help();
+    }
+
+    // Get license file.
+    var license_file = path.join(__dirname, '../licenses/', license + '.txt');
+
+    // Show the license file.
+    console.log(fs.readFileSync(license_file, 'utf8'));
+  });
+
+// Options.
+program.on('--help', function () {
+  console.log('    -y, --year The year to use. Example 2014.');
+  console.log('    -n, --fullname The fullname to use in the license.');
+  console.log('    -p --project The name of the project to use in the license.');
+  console.log('    -e, --extension The file extension for the license. Example: txt. Defaults to no extension.');
+  console.log('');
+});
+
+// Available licenses.
+program.on('--help', function () {
+  console.log('  Available licenses:');
+  console.log('');
+  console.log('    ' + licenses.join("\n    "));
+  console.log('');
+});
+
+// Examples.
+program.on('--help', function () {
+  console.log('  Examples:');
+  console.log('');
+  console.log('    $ license-generator install bsd -y 2014 -n "John Doe" -e txt');
+  console.log('    $ license-generator i mit -y 2014 -n "John Doe"');
+  console.log('    $ license-generator view bsd');
+  console.log('');
+});
+
+program.parse(process.argv);
+
+if (!program.args.length) {
+  program.help();
+}

--- a/index.js
+++ b/index.js
@@ -1,134 +1,24 @@
-#! /usr/bin/env node
-
-var program = require('commander');
 var fs = require('fs');
 
-// Get version from package.json.
-var version = require('./package.json').version;
+module.exports = {
+    install: function(opt, cb) {
+        if(opt.output === undefined || opt.license === undefined || opt.year === undefined || opt.fullname === undefined || opt.projectname === undefined ){
+            return cb('Incomplete options. Require: output, license, year, fullname, projectname');
+        }
+        // Create a LICENSE file.
+        var license_file = __dirname + '/licenses/' + opt.license + '.txt';
+        fs.readFile(license_file, 'utf8', function (err,data) {
+            if (err) {
+                return cb(err);
+            }
 
-// Get available licenses.
-var licenses = [];
-fs.readdirSync(__dirname + '/licenses').map(function (license) {
-  licenses.push(license.replace(/\.[0-9a-z]+$/i, ''));
-});
+            // Make replacements for year and fullname.
+            var result = data
+            .replace(/\[year\]/g, opt.year)
+            .replace(/\[fullname\]/g, opt.fullname)
+            .replace(/\[project\]/g, opt.projectname);
 
-// program
-//   .version(version)
-//   .option("-y, --year <year>", 'The year to use. Example: 2014.')
-//   .option("-n, --fullname <fullname>", 'Your fullname.')
-
-/**
- * Install command.
- * license-generator install [license]
- */
-program
-  .command('install [license]')
-  .alias('i')
-  .description('Use this command to generate a license file.')
-  .option("-y, --year <year>", 'The year to use. Example: 2014.')
-  .option("-n, --fullname <fullname>", 'Your fullname.')
-  .option("-p, --project <project name>", "Project name.")
-  .option("-e, --extension <extension>", 'The file extension for the license. Example: txt. Defaults to no extension.')
-  .action(function (license, options) {
-    // Lowercase the provided license name
-    license = license.toLowerCase();
-
-    // Use provided year or default to current year.
-    var year = options.year || new Date().getUTCFullYear();
-
-    //read from package.json and infer variable if not given
-    var packageJSON = {};
-    try{
-        packageJSON = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-    }catch(err){
+            fs.writeFile(opt.output, result, 'utf8', cb);
+        });
     }
-
-    // Use provided name or default to blank.
-    var fullname = options.fullname || packageJSON.author || '';
-
-    // Use the provided project or default to none
-    var projectname = options.project || packageJSON.name || '';
-
-    // Get file extension.
-    var extension = options.extension || '';
-
-    // Create a LICENSE file.
-    var license_file = __dirname + '/licenses/' + license + '.txt';
-    fs.readFile(license_file, 'utf8', function (err,data) {
-      if (err) {
-        return console.log(err);
-      }
-
-      // Make replacements for year and fullname.
-      var result = data
-                    .replace(/\[year\]/g, year)
-                    .replace(/\[fullname\]/g, fullname)
-                    .replace(/\[project\]/g, projectname);
-
-      var generated_license =  './LICENSE' + ((extension) ? '.' + extension : '');
-      fs.writeFile(generated_license, result, 'utf8', function (err) {
-         if (err) {
-           return console.log(err);
-         }
-
-         // Show a success message.
-         console.log('Successfully added ' + license + ' license to ' + generated_license + ' file.');
-      });
-    });
-  });
-
-/**
- * View command.
- * license-generator view [license]
- */
-program
-  .command('view [license]')
-  .description('Use this command to view the content of a license.')
-  .action(function (license) {
-    // Lowercase the provided license name
-    license = license.toLowerCase();
-
-    if (!license) {
-      console.log('Error: license name missing');
-      program.help();
-    }
-
-    // Get license file.
-    var license_file = __dirname + '/licenses/' + license + '.txt';
-
-    // Show the license file.
-    console.log(fs.readFileSync(license_file, 'utf8'));
-  });
-
-// Options.
-program.on('--help', function () {
-  console.log('    -y, --year The year to use. Example 2014.');
-  console.log('    -n, --fullname The fullname to use in the license.');
-  console.log('    -p --project The name of the project to use in the license.');
-  console.log('    -e, --extension The file extension for the license. Example: txt. Defaults to no extension.');
-  console.log('');
-});
-
-// Available licenses.
-program.on('--help', function () {
-  console.log('  Available licenses:');
-  console.log('');
-  console.log('    ' + licenses.join("\n    "));
-  console.log('');
-});
-
-// Examples.
-program.on('--help', function () {
-  console.log('  Examples:');
-  console.log('');
-  console.log('    $ license-generator install bsd -y 2014 -n "John Doe" -e txt');
-  console.log('    $ license-generator i mit -y 2014 -n "John Doe"');
-  console.log('    $ license-generator view bsd');
-  console.log('');
-});
-
-program.parse(process.argv);
-
-if (!program.args.length) {
-  program.help();
-}
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Generates a license for your open source project.",
   "main": "index.js",
   "preferGlobal": "true",
-  "bin": { "license-generator": "index.js" },
+  "bin": { "license-generator": "./bin/cli.js" },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Besides using cli, can be used using `require`:

```javascript
var licenseGenerator = require('license-generator');
license.install({
            output: './LICENSE',
            license: 'MIT',
            year: 2016,
            fullname: 'tan li hau',
            projectname: 'typescript',
        }, function(err){
            if(err) console.log(err);
        });
```