### PR TITLE
Support to specify the output file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Usage
 
 Generate a license
 
-    $ license-generator install LICENSE -y YEAR -n FULLNAME -e EXTENSION
+    $ license-generator install LICENSE -y YEAR -n FULLNAME -e EXTENSION -o OUTPUT
 
 View a license
 
@@ -28,11 +28,12 @@ Options
     -n, --fullname The fullname to use in the license.
     -p --project The name of the project to use in the license.
     -e, --extension The file extension for the license. Example: txt. Defaults to no extension.
+    -o, --output The output license path. Example: ./LICENSE. Defaults to command executed path.
 
 Examples
 --------------
 
-    $ license-generator install mit -y 2014 -n "John Doe" -e txt
+    $ license-generator install mit -y 2014 -n "John Doe" -e txt -o ./LICENSE
     $ license-generator view mit
 
 Available licenses

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ program
   .option("-n, --fullname <fullname>", 'Your fullname.')
   .option("-p, --project <project name>", "Project name.")
   .option("-e, --extension <extension>", 'The file extension for the license. Example: txt. Defaults to no extension.')
+  .option("-o, --output <output path>", 'The output license path.')
   .action(function (license, options) {
     // Lowercase the provided license name
     license = license.toLowerCase();
@@ -52,6 +53,8 @@ program
     // Get file extension.
     var extension = options.extension || '';
 
+    var output = options.output || './LICENSE';
+
     // Create a LICENSE file.
     var license_file = __dirname + '/licenses/' + license + '.txt';
     fs.readFile(license_file, 'utf8', function (err,data) {
@@ -65,7 +68,7 @@ program
                     .replace(/\[fullname\]/g, fullname)
                     .replace(/\[project\]/g, projectname);
 
-      var generated_license =  './LICENSE' + ((extension) ? '.' + extension : '');
+      var generated_license =  output + ((extension) ? '.' + extension : '');
       fs.writeFile(generated_license, result, 'utf8', function (err) {
          if (err) {
            return console.log(err);
@@ -106,6 +109,7 @@ program.on('--help', function () {
   console.log('    -n, --fullname The fullname to use in the license.');
   console.log('    -p, --project The name of the project to use in the license.');
   console.log('    -e, --extension The file extension for the license. Example: txt. Defaults to no extension.');
+  console.log('    -o, --output The output license path. Example: ./LICENSE. Defaults to command executed path.');
   console.log('');
 });
 
@@ -121,7 +125,7 @@ program.on('--help', function () {
 program.on('--help', function () {
   console.log('  Examples:');
   console.log('');
-  console.log('    $ license-generator install bsd -y 2014 -n "John Doe" -e txt');
+  console.log('    $ license-generator install bsd -y 2014 -n "John Doe" -e txt -o ./LICENSE');
   console.log('    $ license-generator i mit -y 2014 -n "John Doe"');
   console.log('    $ license-generator view bsd');
   console.log('');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/arshad/license-generator",
   "dependencies": {
-    "commander": "~2.1.0"
+    "commander": "~2.3.0"
   }
 }


### PR DESCRIPTION
Before my work, I update commander to `v2.3.0`. I found the `alias` in `install` command is not supported in `v2.1.0` which is declared in origin `package.json`. You can see the [CHANGELOG of commander](https://github.com/tj/commander.js/blob/4ef19faac1564743d8c7e3ce89ef8d190e1551b4/CHANGELOG.md?plain=1#L963), the `alias` command was be add in `v2.3.0`.

I add the `--output` option to `install` command arguments, then update the `--help` command to introduce.

By the way, I think it is wisely to deprecate the `--extension` option, the extension of license should be also declared in output path.